### PR TITLE
feat: boat player and slow missiles in level 3

### DIFF
--- a/sammygame.html
+++ b/sammygame.html
@@ -557,31 +557,73 @@
     function drawShip() {
       const x = player.x, y = player.y, s = 18;
       ctx.save();
-      ctx.shadowColor = currentMode === Modes.BATS ? '#ff7a00' : (currentMode===Modes.JELLIES ? '#66ffd4' : '#7afcff');
-      ctx.shadowBlur = 15;
-      ctx.fillStyle = currentMode===Modes.BATS ? '#ffa64d' : (currentMode===Modes.JELLIES ? '#66ffee' : '#aef');
-      ctx.beginPath();
-      ctx.moveTo(x, y - s);
-      ctx.lineTo(x - s*0.7, y + s*0.9);
-      ctx.lineTo(x + s*0.7, y + s*0.9);
-      ctx.closePath(); ctx.fill();
-      ctx.shadowBlur = 0;
+
+      if (currentMode === Modes.JELLIES) {
+        // Water background under the ship
+        const waterTop = y + s * 0.9;
+        ctx.fillStyle = 'rgba(0,80,160,0.4)';
+        ctx.fillRect(0, waterTop, canvas.width, canvas.height - waterTop);
+        ctx.strokeStyle = '#00aaff';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(0, waterTop);
+        ctx.lineTo(canvas.width, waterTop);
+        ctx.stroke();
+
+        // Simple boat hull
+        ctx.fillStyle = '#b5651d';
+        ctx.beginPath();
+        ctx.moveTo(x - s, y);
+        ctx.lineTo(x + s, y);
+        ctx.lineTo(x + s * 0.6, y + s * 0.8);
+        ctx.lineTo(x - s * 0.6, y + s * 0.8);
+        ctx.closePath();
+        ctx.fill();
+
+        // Cabin / mast
+        ctx.fillStyle = '#eee';
+        ctx.beginPath();
+        ctx.moveTo(x, y - s);
+        ctx.lineTo(x, y);
+        ctx.lineTo(x + s * 0.6, y);
+        ctx.closePath();
+        ctx.fill();
+      } else {
+        ctx.shadowColor = currentMode === Modes.BATS ? '#ff7a00' : '#7afcff';
+        ctx.shadowBlur = 15;
+        ctx.fillStyle = currentMode === Modes.BATS ? '#ffa64d' : '#aef';
+        ctx.beginPath();
+        ctx.moveTo(x, y - s);
+        ctx.lineTo(x - s * 0.7, y + s * 0.9);
+        ctx.lineTo(x + s * 0.7, y + s * 0.9);
+        ctx.closePath();
+        ctx.fill();
+        ctx.shadowBlur = 0;
+      }
+
       ctx.restore();
     }
 
     class Bullet {
       constructor(x, y, dir) {
         this.x = x; this.y = y; this.dir = dir; // -1 up, +1 down
-        this.speed = 620;
-        this.r = 3.5;
+        this.speed = currentMode === Modes.JELLIES ? 200 : 620;
+        this.r = currentMode === Modes.JELLIES ? 6 : 3.5;
       }
       update(deltaSec) {
         this.y += this.dir * this.speed * deltaSec; // bullets ignore slow-mo
         return (this.y > -20 && this.y < canvas.height + 20);
       }
       draw() {
-        ctx.fillStyle = '#fff';
-        ctx.beginPath(); ctx.arc(this.x, this.y, this.r, 0, Math.PI*2); ctx.fill();
+        if (currentMode === Modes.JELLIES) {
+          ctx.fillStyle = '#ddd';
+          ctx.fillRect(this.x - 3, this.y - 8, 6, 16);
+          ctx.fillStyle = '#f00';
+          ctx.fillRect(this.x - 5, this.y + 8, 10, 4);
+        } else {
+          ctx.fillStyle = '#fff';
+          ctx.beginPath(); ctx.arc(this.x, this.y, this.r, 0, Math.PI*2); ctx.fill();
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Draw a boat-shaped player that floats on water in level 3
- Add slow downward missiles for level 3 with new sprite and speed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4aefb5ed8832d87b473a707201a21