### PR TITLE
Randomize math problems per level

### DIFF
--- a/sammygame.html
+++ b/sammygame.html
@@ -323,6 +323,14 @@
 
     const questionIndex = { 1:0, 2:0, 3:0, 4:0 };
 
+    function shuffleQuestionsForLevel(lvl) {
+      const arr = levelQuestions[lvl];
+      for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+      }
+    }
+
     // ===== Difficulty pacing per level =====
     // Level 1 (3D) keeps your original pacing
     const level1Params = { speedRange: [0.20, 0.35], spawnPerSec: 0.60, zStart: 360 };
@@ -1206,6 +1214,7 @@
         player.topMode = false; player.bulletDir = -1; clampPlayer();
         initStars();
       }
+      shuffleQuestionsForLevel(lvl);
       questionIndex[lvl] = 0;
       levelGoal = levelQuestions[lvl].length;
       levelEl.textContent = lvl;


### PR DESCRIPTION
## Summary
- Randomize question order for each level to avoid predictable math problems

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f2458758832d87c324e049628777